### PR TITLE
0 point color in options and Reset Profile error

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -122,7 +122,7 @@ function ComboPointsRedux:OnInitialize()
 					spacing = 5,
 					width = 250,
 					height = 25,
-					emptyPointAlpha = .2,
+					emptyPointAlpha = 0.0,
 					scale = 1,
 					strata = "HIGH",
 					graphicsX = nil,
@@ -215,8 +215,8 @@ function ComboPointsRedux:Reset()
 		
 		local offset = db.spacing--*db.scale
 		
-		
-		for i = 1, module.MAX_POINTS do
+		local num = module.MAX_POINTS
+		for i = 1, num do
 			module.graphics.points[i].icon:SetTexture(basepath..db.icon)
 			module.graphics.points[i]:SetWidth(((db.width*db.scale)-(offset*(num-1)))/num)
 			module.graphics.points[i]:SetHeight(db.height*db.scale)
@@ -233,8 +233,8 @@ function ComboPointsRedux:Reset()
 		end
 		
 		module.graphics.points[1]:SetPoint("BOTTOMLEFT", module.graphics, "BOTTOMLEFT", 0, 0)
-		if module.MAX_POINTS > 1 then
-			for i = 2, module.MAX_POINTS do
+		if num > 1 then
+			for i = 2, num do
 				module.graphics.points[i]:SetPoint("BOTTOMLEFT", module.graphics, "BOTTOMLEFT", ((((db.width*db.scale)-(offset*(num-1)))/num)*(i-1))+(offset*(i-1)), 0)
 			end
 		end
@@ -376,9 +376,9 @@ function ComboPointsRedux:UpdateSettings(name)
 	if not db.disableGraphics then
 		--change icon textures
 		--update icon Alpha
-		for i = 1, module.MAX_POINTS do
+		for i = 1, num do
 			module.graphics.points[i].icon:SetTexture(basepath..db.icon)
-			module.graphics.points[i].icon:SetVertexColor(unpack(db.colors[1]))
+			module.graphics.points[i].icon:SetVertexColor(unpack(db.colors[module.Count]))
 			module.graphics.points[i]:SetWidth(((db.width*db.scale)-(offset*(num-1)))/num)
 			module.graphics.points[i]:SetHeight(db.height*db.scale)
 			module.graphics.points[i]:ClearAllPoints()
@@ -403,15 +403,15 @@ function ComboPointsRedux:UpdateSettings(name)
 		--adjust for orientation changes (this updates spacing too)
 		if db.orientation == "v" then
 			module.graphics.points[1]:SetPoint("BOTTOM", module.graphics, "BOTTOM", 0, 0)
-			if module.MAX_POINTS > 1 then
-				for i = 2, module.MAX_POINTS do
+			if num > 1 then
+				for i = 2, num do
 					module.graphics.points[i]:SetPoint("BOTTOM", module.graphics.points[i-1], "TOP", 0, offset)
 				end
 			end
 		else
 			module.graphics.points[1]:SetPoint("BOTTOMLEFT", module.graphics, "BOTTOMLEFT", 0, 0)
-			if module.MAX_POINTS > 1 then
-				for i = 2, module.MAX_POINTS do
+			if num > 1 then
+				for i = 2, num do
 					module.graphics.points[i]:SetPoint("BOTTOMLEFT", module.graphics, "BOTTOMLEFT", ((((db.width*db.scale)-(offset*(num-1)))/num)*(i-1))+(offset*(i-1)), 0)
 				end
 			end
@@ -452,7 +452,6 @@ function ComboPointsRedux:UpdateSettings(name)
 	
 	--Update some class specific show/hide options
 	local CLASS = select(2, UnitClass("player"))
-	
 	if CLASS == "DRUID" then
 		if db.hideOutCat then
 			local form = GetShapeshiftForm(true)
@@ -475,48 +474,6 @@ function ComboPointsRedux:UpdateSettings(name)
 					if module.text then module.text:Hide() end
 					if module.graphics then module.graphics:Hide() end
 				end
-			end
-		end
-	elseif CLASS == "WARLOCK" then
-		local spec = GetSpecialization()
-	
-		if name == "Burning Embers" then
-			if spec == 3 then
-				--3 is destruction
-				if db.hideOOC then
-					if InCombatLockdown() then
-						if module.text then module.text:Show() end
-						if module.graphics then module.graphics:Show() end
-					else
-						if module.text then module.text:Hide() end
-						if module.graphics then module.graphics:Hide() end
-					end
-				else
-					if module.text then module.text:Show() end
-					if module.graphics then module.graphics:Show() end
-				end
-			else
-				if module.text then module.text:Hide() end
-				if module.graphics then module.graphics:Hide() end
-			end
-		elseif name == "Soul Shards" then
-			if spec == 1 then
-				--1 is affliction
-				if db.hideOOC then
-					if InCombatLockdown() then
-						if module.text then module.text:Show() end
-						if module.graphics then module.graphics:Show() end
-					else
-						if module.text then module.text:Hide() end
-						if module.graphics then module.graphics:Hide() end
-					end
-				else
-					if module.text then module.text:Show() end
-					if module.graphics then module.graphics:Show() end
-				end
-			else
-				if module.text then module.text:Hide() end
-				if module.graphics then module.graphics:Hide() end
 			end
 		end
 	end
@@ -676,7 +633,7 @@ function ComboPointsRedux:MakeGraphicsFrame(moduleName, num, count)
 		g.points[i].icon = g.points[i]:CreateTexture(nil, "OVERLAY")
 		g.points[i].icon:SetAllPoints(g.points[i])
 		g.points[i].icon:SetTexture(basepath..db.icon)
-		g.points[i].icon:SetVertexColor(unpack(db.colors[1]))
+		g.points[i].icon:SetVertexColor(unpack(db.colors[count]))
 		g.points[i]:SetAlpha(db.emptyPointAlpha)
 		g.points[i]:SetHeight(db.height*db.scale)
 		g.points[i]:SetWidth(((db.width*db.scale)-(offset*(num-1)))/num)

--- a/Modules/Arcane.lua
+++ b/Modules/Arcane.lua
@@ -35,13 +35,8 @@ end
 
 local oldCount = 0
 function mod:Update()
-	self.Count = UnitPower("player", SPELL_POWER_ARCANE_CHARGES)
-	--GetColorByPoints returns default color if count is 0, so use count of 1 if at 0
-	local CountForColor = 1
-	if self.Count > 0 then
-		CountForColor = self.Count
-	end
-	local r, g, b = cpr:GetColorByPoints(modName, CountForColor)
+	self.Count = UnitPower("player", SPELL_POWER_ARCANE_CHARGES) or 0
+	local r, g, b = cpr:GetColorByPoints(modName, self.Count)
 	local a, a2 = cpr:GetAlphas(modName)
 	
 	if self.Count > 0 then

--- a/Modules/Chi.lua
+++ b/Modules/Chi.lua
@@ -33,12 +33,8 @@ end
 
 local oldCount = 0
 function mod:Update()
-	self.Count = UnitPower("player", SPELL_POWER_CHI)
-	local CountForColor = 1
-	if self.Count > 0 then
-		CountForColor = self.Count
-	end
-	local r, g, b = cpr:GetColorByPoints(modName, CountForColor)
+	self.Count = UnitPower("player", SPELL_POWER_CHI) or 0
+	local r, g, b = cpr:GetColorByPoints(modName, self.Count)
 	local a, a2 = cpr:GetAlphas(modName)
 	
 	if self.Count > 0 then

--- a/Modules/Combo.lua
+++ b/Modules/Combo.lua
@@ -43,7 +43,7 @@ function mod:OnInitialize()
 	end
 	self.Count = UnitPower("player", SPELL_POWER_COMBO_POINTS)
 	self.displayName = COMBAT_TEXT_SHOW_COMBO_POINTS_TEXT
-	self.events = { ["UNIT_POWER"] = "Update", ["SPELLS_CHANGED"] = "UpdateMaxPoints", ["PLAYER_SPECIALIZATION_CHANGED"] = "UpdateMaxPoints" }
+	self.events = { ["UNIT_POWER"] = "Update", ["SPELLS_CHANGED"] = "UpdateMaxPoints", ["PLAYER_SPECIALIZATION_CHANGED"] = "UpdateMaxPoints", ["PLAYER_LOGIN"] = "UpdateMaxPoints" }
 end
 
 function mod:OnModuleEnable()
@@ -52,12 +52,8 @@ end
 
 local oldPoints = 0
 function mod:Update()
-	self.Count = UnitPower("player", SPELL_POWER_COMBO_POINTS)
-	local CountForColor = 1
-	if self.Count > 0 then
-		CountForColor = self.Count
-	end
-	local r, g, b = cpr:GetColorByPoints(modName, CountForColor)
+	self.Count = UnitPower("player", SPELL_POWER_COMBO_POINTS) or 0
+	local r, g, b = cpr:GetColorByPoints(modName, self.Count)
 	local a, a2 = cpr:GetAlphas(modName)
 	
 	if self.Count > 0 then
@@ -118,19 +114,20 @@ function mod:UpdateMaxPoints()
 		end
 	else
 		self.MAX_POINTS = 0
-	end
-	
+	end	
 	if self.graphics then
 		for i = 1, 8 do
 			self.graphics.points[i]:Hide()
 			self.graphics.points[i]:SetAlpha(a2)
 		end
-		for i = 1, self.MAX_POINTS do
-			self.graphics.points[i]:Show()
-		end
-		if self.Count > 0 then
-			for i = 1, self.Count do
-				self.graphics.points[i]:SetAlpha(a)
+		if self.MAX_POINTS > 0 then
+			for i = 1, self.MAX_POINTS do
+				self.graphics.points[i]:Show()
+			end
+			if self.Count > 0 then
+				for i = 1, self.Count do
+					self.graphics.points[i]:SetAlpha(a)
+				end
 			end
 		end
 	end

--- a/Modules/HolyPower.lua
+++ b/Modules/HolyPower.lua
@@ -34,12 +34,8 @@ end
 
 local oldCount = 0
 function mod:Update()
-	self.Count = UnitPower("player", SPELL_POWER_HOLY_POWER)
-	local CountForColor = 1
-	if self.Count > 0 then
-		CountForColor = self.Count
-	end
-	local r, g, b = cpr:GetColorByPoints(modName, CountForColor)
+	self.Count = UnitPower("player", SPELL_POWER_HOLY_POWER) or 0
+	local r, g, b = cpr:GetColorByPoints(modName, self.Count)
 	local a, a2 = cpr:GetAlphas(modName)
 	
 	if self.Count > 0 then

--- a/Modules/SoulShards.lua
+++ b/Modules/SoulShards.lua
@@ -25,17 +25,13 @@ function mod:OnInitialize()
 	self.Count = UnitPower("player", SPELL_POWER_SOUL_SHARDS)
 	self.displayName = SOUL_SHARDS_POWER
 	self.abbrev = "SS"
-	self.events = { ["UNIT_POWER"] = "Update", ["UNIT_DISPLAYPOWER"] = "Update" }
+	self.events = { ["UNIT_POWER"] = "Update", ["UNIT_DISPLAYPOWER"] = "Update", ["PLAYER_LOGIN"] = "Update" }
 end
 
 local oldCount = 0
 function mod:Update()
-	self.Count = UnitPower("player", SPELL_POWER_SOUL_SHARDS)
-	local CountForColor = 1
-	if self.Count > 0 then
-		CountForColor = self.Count
-	end
-	local r, g, b = cpr:GetColorByPoints(modName, CountForColor)
+	self.Count = UnitPower("player", SPELL_POWER_SOUL_SHARDS) or 0
+	local r, g, b = cpr:GetColorByPoints(modName, self.Count)
 	local a, a2 = cpr:GetAlphas(modName)
 	
 	if self.Count > 0 then

--- a/Options/Options.lua
+++ b/Options/Options.lua
@@ -243,12 +243,12 @@ for name, module in core:IterateModules() do
 				args = {
 					oneColor = {
 						type = 'color',
-						name = format(L["%d |4Point:Points;"], 1),
-						desc = format(L["Set the color to be used when you have %d |4point:points;."], 1),
-						arg = 1,
+						name = format(L["%d |4Point:Points;"], 0),
+						desc = format(L["Set the color to be used when you have %d |4point:points;."], 0),
+						arg = 0,
 						get = "Get",
 						set = "Set",
-						order = 1,
+						order = 0,
 					},
 					iconStyle = {
 						type = "select",
@@ -586,7 +586,7 @@ for name, module in core:IterateModules() do
 		},
 	}
 	
-	for j = 2, module.MAX_POINTS do
+	for j = 1, module.MAX_POINTS do
 		opts.args[name].args.graphics.args["color"..j] = {
 			type = 'color',
 			name = format(L["%d |4Point:Points;"], j),


### PR DESCRIPTION
Added 0 point color in options. Good option to have, and now I can get
rid of a couple lines in each module about CountForColor.

Was using a variable that didn't exist in Reset(), added it.

UpdateSettings and MakeGraphicsFrame were using 1 point color, changed
to use current count.

Also added "or 0" when setting current count to prevent it ever being
nil. Had it happen once to me today, couldn't replicate it.